### PR TITLE
Switch from `--af_gnomad` (exomes) to `--af_gnomadg` (genomes) for Ensembl VEP 107

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -482,7 +482,7 @@ unless( $inhibit_vep ) {
     if( $species eq "homo_sapiens" ) {
         # Slight change in options if in offline mode, or if using the newer VEP
         $vep_cmd .= " --polyphen b" . ( $vep_script =~ m/vep$/ ? " --af" : " --gmaf" );
-        $vep_cmd .= ( $vep_script =~ m/vep$/ ? " --af_1kg --af_gnomad" : " --maf_1kg --maf_esp" ) unless( $online );
+        $vep_cmd .= ( $vep_script =~ m/vep$/ ? " --af_1kg --af_gnomadg" : " --maf_1kg --maf_esp" ) unless( $online );
     }
     # Do not use the --regulatory option in situations where we know it will break
     $vep_cmd .= " --regulatory" unless( $species eq "canis_familiaris" or $online );
@@ -514,8 +514,9 @@ my @ann_cols = qw( Allele Gene Feature Feature_type Consequence cDNA_position CD
     SYMBOL_SOURCE HGNC_ID BIOTYPE CANONICAL CCDS ENSP SWISSPROT TREMBL UNIPARC RefSeq SIFT PolyPhen
     EXON INTRON DOMAINS AF AFR_AF AMR_AF ASN_AF EAS_AF EUR_AF SAS_AF AA_AF EA_AF CLIN_SIG SOMATIC
     PUBMED MOTIF_NAME MOTIF_POS HIGH_INF_POS MOTIF_SCORE_CHANGE IMPACT PICK VARIANT_CLASS TSL
-    HGVS_OFFSET PHENO MINIMISED GENE_PHENO FILTER flanking_bps vcf_id vcf_qual gnomAD_AF gnomAD_AFR_AF
-    gnomAD_AMR_AF gnomAD_ASJ_AF gnomAD_EAS_AF gnomAD_FIN_AF gnomAD_NFE_AF gnomAD_OTH_AF gnomAD_SAS_AF );
+    HGVS_OFFSET PHENO MINIMISED GENE_PHENO FILTER flanking_bps vcf_id vcf_qual gnomADg_AF 
+    gnomADg_AFR_AF gnomADg_AMR_AF gnomADg_ASJ_AF gnomADg_EAS_AF gnomADg_FIN_AF gnomADg_NFE_AF 
+    gnomADg_OTH_AF gnomADg_SAS_AF );
 
 # push any requested custom VEP annotations from the CSQ/ANN section into @ann_cols
 if ($retain_ann) {
@@ -885,8 +886,8 @@ while( my $line = $annotated_vcf_fh->getline ) {
     # Copy FILTER from input VCF, and tag calls with high allele freq in any gnomAD subpopulation
     my $subpop_count = 0;
     foreach my $subpop ( qw( AFR AMR ASJ EAS FIN NFE SAS )) {
-        if( $maf_line{"gnomAD_$subpop\_AF"} ) {
-            my ( $subpop_af ) = split( "/", $maf_line{"gnomAD_$subpop\_AF"} );
+        if( $maf_line{"gnomADg_$subpop\_AF"} ) {
+            my ( $subpop_af ) = split( "/", $maf_line{"gnomADg_$subpop\_AF"} );
             $subpop_count++ if( $subpop_af > $max_subpop_af );
         }
     }


### PR DESCRIPTION
I noticed that the `gnomAD_*AF` columns in the MAF file were empty, whereas the corresponding fields in the VEP-annotated VCF file had data in them. I realized that VEP 107 updated the gnomAD-related options ([docs](https://uswest.ensembl.org/info/docs/tools/vep/script/vep_options.html#:~:text=%2D%2Daf_gnomade-,%2D%2Daf_gnomad,-Include%20allele%20frequency)). Specifically, `--af_gnomad` now mapped to `--af_gnomade`, which annotates using `gnomADe_*AF` (with an "e" for exomes). I figured we wanted to take advantage of the new genomes available for GRCh38 ([source](https://www.ensembl.info/2022/07/12/ensembl-107-has-been-released/)), so I updated vcf2maf to use `--af_gnomadg` instead, which annotates using `gnomADg_*AF` (with a "g"). 

> New population frequencies from the gnomAD 3.1.2 genomes collection are available in the Ensembl VEP cache (cache file size increases ~30-50% for GRCh38) and via all interfaces. Data from NHLBI GO-ESP is no longer supported as this is part of the gnomAD exome data available in Ensembl VEP.